### PR TITLE
Add custom entries option

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -36,9 +36,11 @@ export default function axiosRetry(axios, { retries = 3 } = {}) {
       return Promise.reject(error);
     }
 
+    const maxRetries = config.retries || retries;
+
     config.retryCount = config.retryCount || 0;
 
-    if (!error.response && config.retryCount < retries && isRetryAllowed(error)) {
+    if (!error.response && config.retryCount < maxRetries && isRetryAllowed(error)) {
       config.retryCount++;
 
       // Axios fails merging this configuration to the default configuration because it has an issue

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -58,6 +58,26 @@ describe('axiosRetry(axios, { retries })', () => {
     }, done.fail);
   });
 
+  it('should resolve with a succesful response after an error with custom retries', done => {
+    const client = axios.create();
+    setupResponses(client, [
+      () => nock('http://example.com').get('/test').replyWithError(NETWORK_ERROR),
+      () => nock('http://example.com').get('/test').replyWithError(NETWORK_ERROR),
+      () => nock('http://example.com').get('/test').reply(200, 'It worked!')
+    ]);
+
+    axiosRetry(client, { retries: 1 });
+
+    client({
+      url: 'http://example.com/test',
+      method: 'get',
+      retries: 2
+    }).then(result => {
+      expect(result.status).toBe(200);
+      done();
+    }, done.fail);
+  });
+
   it('should resolve with a succesful response after an error (with agent)', done => {
     const httpAgent = new http.Agent();
 


### PR DESCRIPTION
Hi,

I could be great to add the possibility of overriding the current retries configuration (example, I would like to have 1 retry for all request but 2 on a specific request)