### PR TITLE
Allow retries on non-error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ client.get('/test') // The first request fails and the second returns 'ok'
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | retries | `Number` | 3 | The number of times to retry before failing |
-| retryCondition | `Function` | `error => !error.response` | A callback to further control if a request should be retried.  By default, it retries if the result did not have a response. |
+| retryCondition | `Function` | `(error, response) => error && !error.response` | A callback to further control if a request should be retried.  By default, it retries if the result did not have a response. |
 
 ## Testing
 

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -43,6 +43,28 @@ describe('axiosRetry(axios, { retries })', () => {
     }, done.fail);
   });
 
+  it('should resolve with a succesful response after object with "error" key', done => {
+    const client = axios.create();
+    setupResponses(client, [
+      () => nock('http://example.com').get('/test').reply(200, {
+        error: 'should retry'
+      }),
+      () => nock('http://example.com').get('/test').reply(200, 'It worked!')
+    ]);
+
+    axiosRetry(client, {
+      retries: 1,
+      retryCondition: (err, res) => {
+        return res && !!res.data.error;
+      }
+    });
+
+    client.get('http://example.com/test').then(result => {
+      expect(result.status).toBe(200);
+      done();
+    }, done.fail);
+  });
+
   it('should resolve with a succesful response after an error', done => {
     const client = axios.create();
     setupResponses(client, [


### PR DESCRIPTION
Adds ability to retry successful responses per `retryCondition()`.

Needed in my case for GraphQL requests. GraphQL always returns a 200 status. The error will be in the JSON-encoded response body.