### PR TITLE
add useIsRetryAllowed option, tests and documentation for fine grained retry control

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,7 @@
         "params": "param"
       }
     }],
-    "complexity": ["warn", 7], // Warn about excessive complexity
+    "complexity": ["warn", 8], // Warn about excessive complexity
     "no-param-reassign": ["error", { "props": false }], // To enable request.params.something = ...;
     "no-underscore-dangle": ["error", { "allowAfterThis": true }], // To enable this._p = 'value';
 
@@ -32,6 +32,7 @@
     "padded-blocks": "off", // Allow spaces at the beginning of blocks
     "newline-per-chained-call": "off", // Allow chaining in a single line: Joi.string().required()
     "consistent-return": "off", // Allow if (error) { return ... } and no final return
-    "arrow-body-style": "off" // Allow arrow functions with only a return statement
+    "arrow-body-style": "off", // Allow arrow functions with only a return statement
+    "max-len": ["error", { "ignoreComments": true }] // Allow 80+ char lines in comments
   }
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ client.get('/test') // The first request fails and the second returns 'ok'
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | retries | `Number` | 3 | The number of times to retry before failing |
-| retryCondition | `Function` | `error => !error.response` | A callback to further control if a request should be retried.  By default, it retries if the result did not have a response. |
+| retryCondition | `Function` | `error => !error.response && error.code !== 'ECONNABORTED'` | A callback to further control if a request should be retried.  By default, it retries if the result did not have a response and the errorcode is not 'ECONNABORTED'. |
+| useIsRetryAllowed | `Boolean` | `true` | use the "is-retry-allowed" module additionally to the `retryCondition` function to determine if the request should be retried |
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "axios-retry",
+  "name": "axios-retry-fork",
   "version": "1.2.0",
   "author": "Rubén Norte <ruben.norte@softonic.com>",
-  "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
+  "description": "Axios plugin that intercepts failed requests and retries them whenever possible. FORK: even on timeouts and stuff! :)",
   "license": "Apache-2.0",
   "main": "index.js",
-  "homepage": "https://github.com/softonic/axios-retry",
+  "homepage": "https://github.com/erdii/axios-retry",
   "files": [
     "es",
     "lib",
@@ -39,9 +39,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/softonic/axios-retry.git"
+    "url": "git+https://github.com/erdii/axios-retry.git"
   },
   "bugs": {
-    "url": "https://github.com/softonic/axios-retry/issues"
+    "url": "https://github.com/erdii/axios-retry/issues"
   }
 }


### PR DESCRIPTION
I changed the `shouldRetry` line to:

```
const shouldRetry = retryCondition(error)
      && (useIsRetryAllowed ? isRetryAllowed(error) : true)
      && config.retryCount < retries;
```

Then I added tests and documentation.

Sorry that i had to fumble around in the `.eslintrc` :( It was a bit restrictive about function-complexity and line-length.