### PR TITLE
Added in delay strategy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ client
 | --- | --- | --- | --- |
 | retries | `Number` | 3 | The number of times to retry before failing |
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
-| retryDelay | `Function` | `0` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). |
+| retryDelay | `Function` | `0` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ axios.get('http://example.com/test') // The first request fails and the second r
     result.data; // 'ok'
   });
 
-// Exponential back-off delay between requests
-axiosRetry(axios, { delayStrategy: axiosRetry.exponentialDelay});
+// Exponential back-off retry delay between requests
+axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay});
 
-// Custom delay strategy
-axiosRetry(axios, { delayStrategy: (retryCount) => {
+// Custom retry delay
+axiosRetry(axios, { retryDelay: (retryCount) => {
   return retryCount * 1000;
 }});
 
@@ -61,7 +61,7 @@ client
 | --- | --- | --- | --- |
 | retries | `Number` | 3 | The number of times to retry before failing |
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
-| delayStrategy | `Function` | `noDelay` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). |
+| retryDelay | `Function` | `0` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ axios.get('http://example.com/test') // The first request fails and the second r
     result.data; // 'ok'
   });
 
+// Exponential back-off delay between requests
+axiosRetry(axios, { delayStrategy: axiosRetry.exponentialDelay});
+
+// Custom delay strategy
+axiosRetry(axios, { delayStrategy: (retryCount) => {
+  return retryCount * 1000;
+}});
+
 // Works with custom axios instances
 const client = axios.create({ baseURL: 'http://example.com' });
 axiosRetry(client, { retries: 3 });
@@ -53,6 +61,7 @@ client
 | --- | --- | --- | --- |
 | retries | `Number` | 3 | The number of times to retry before failing |
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
+| delayStrategy | `Function` | `noDelay` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). |
 
 ## Testing
 

--- a/es/index.js
+++ b/es/index.js
@@ -62,7 +62,7 @@ export function isNetworkOrIdempotentRequestError(error) {
 /**
  * @return {number} - delay in milliseconds, always 1
  */
-export function noDelay() {
+function noDelay() {
   return 1;
 }
 
@@ -215,5 +215,4 @@ axiosRetry.isNetworkError = isNetworkError;
 axiosRetry.isSafeRequestError = isSafeRequestError;
 axiosRetry.isIdempotentRequestError = isIdempotentRequestError;
 axiosRetry.isNetworkOrIdempotentRequestError = isNetworkOrIdempotentRequestError;
-axiosRetry.noDelay = noDelay;
 axiosRetry.exponentialDelay = exponentialDelay;

--- a/es/index.js
+++ b/es/index.js
@@ -126,6 +126,14 @@ function fixConfig(axios, config) {
  *     result.data; // 'ok'
  *   });
  *
+ * // Exponential back-off delay between requests
+ * axiosRetry(axios, { delayStrategy: axiosRetry.exponentialDelay});
+ *
+ * // Custom delay strategy
+ * axiosRetry(axios, { delayStrategy: (retryCount) => {
+ *   return retryCount * 1000;
+ * }});
+ *
  * // Also works with custom axios instances
  * const client = axios.create({ baseURL: 'http://example.com' });
  * axiosRetry(client, { retries: 3 });
@@ -151,6 +159,8 @@ function fixConfig(axios, config) {
  * @param {number} [defaultOptions.retries=3] Number of retries
  * @param {Function} [defaultOptions.retryCondition=isNetworkOrIdempotentRequestError]
  *        A function to determine if the error can be retried
+ * @param {Function} [defaultOptions.delayStrategy=noDelay]
+ *        A function to determine the delay between retry requestss
  */
 export default function axiosRetry(axios, defaultOptions) {
   axios.interceptors.request.use((config) => {

--- a/es/index.js
+++ b/es/index.js
@@ -60,10 +60,10 @@ export function isNetworkOrIdempotentRequestError(error) {
 }
 
 /**
- * @return {number} - delay in milliseconds, always 1
+ * @return {number} - delay in milliseconds, always 0
  */
 function noDelay() {
-  return 1;
+  return 0;
 }
 
 /**

--- a/es/index.js
+++ b/es/index.js
@@ -126,11 +126,11 @@ function fixConfig(axios, config) {
  *     result.data; // 'ok'
  *   });
  *
- * // Exponential back-off delay between requests
- * axiosRetry(axios, { delayStrategy: axiosRetry.exponentialDelay});
+ * // Exponential back-off retry delay between requests
+ * axiosRetry(axios, { retryDelay : axiosRetry.exponentialDelay});
  *
- * // Custom delay strategy
- * axiosRetry(axios, { delayStrategy: (retryCount) => {
+ * // Custom retry delay
+ * axiosRetry(axios, { retryDelay : (retryCount) => {
  *   return retryCount * 1000;
  * }});
  *
@@ -159,7 +159,7 @@ function fixConfig(axios, config) {
  * @param {number} [defaultOptions.retries=3] Number of retries
  * @param {Function} [defaultOptions.retryCondition=isNetworkOrIdempotentRequestError]
  *        A function to determine if the error can be retried
- * @param {Function} [defaultOptions.delayStrategy=noDelay]
+ * @param {Function} [defaultOptions.retryDelay =noDelay]
  *        A function to determine the delay between retry requestss
  */
 export default function axiosRetry(axios, defaultOptions) {
@@ -180,7 +180,7 @@ export default function axiosRetry(axios, defaultOptions) {
     const {
       retries = 3,
       retryCondition = isNetworkOrIdempotentRequestError,
-      delayStrategy = noDelay
+      retryDelay = noDelay
     } = getRequestOptions(config, defaultOptions);
 
     const currentState = getCurrentState(config);
@@ -202,7 +202,7 @@ export default function axiosRetry(axios, defaultOptions) {
       }
 
       return new Promise((resolve) =>
-        setTimeout(() => resolve(axios(config)), delayStrategy(currentState.retryCount))
+        setTimeout(() => resolve(axios(config)), retryDelay(currentState.retryCount))
       );
     }
 

--- a/es/index.js
+++ b/es/index.js
@@ -67,11 +67,13 @@ function noDelay() {
 }
 
 /**
- * @param  {number} retryNumber
+ * @param  {number} [retryNumber=0]
  * @return {number} - delay in milliseconds
  */
-export function exponentialDelay(retryNumber) {
-  return (Math.pow(2, (retryNumber - 1)) * 1000) + Math.floor(Math.random() * 1000);
+export function exponentialDelay(retryNumber = 0) {
+  const delay = Math.pow(2, retryNumber) * 100;
+  const randomSum = delay * 0.2 * Math.random(); // 0-20% of the delay
+  return delay + randomSum;
 }
 
 /**

--- a/es/index.js
+++ b/es/index.js
@@ -159,8 +159,8 @@ function fixConfig(axios, config) {
  * @param {number} [defaultOptions.retries=3] Number of retries
  * @param {Function} [defaultOptions.retryCondition=isNetworkOrIdempotentRequestError]
  *        A function to determine if the error can be retried
- * @param {Function} [defaultOptions.retryDelay =noDelay]
- *        A function to determine the delay between retry requestss
+ * @param {Function} [defaultOptions.retryDelay=noDelay]
+ *        A function to determine the delay between retry requests
  */
 export default function axiosRetry(axios, defaultOptions) {
   axios.interceptors.request.use((config) => {

--- a/es/index.js
+++ b/es/index.js
@@ -202,7 +202,7 @@ export default function axiosRetry(axios, defaultOptions) {
       }
 
       return new Promise((resolve) =>
-        setTimeout(() => resolve(axios(config)), retryDelay(currentState.retryCount))
+        setTimeout(() => resolve(axios(config)), retryDelay(currentState.retryCount, error))
       );
     }
 

--- a/es/index.js
+++ b/es/index.js
@@ -71,7 +71,7 @@ function noDelay() {
  * @return {number} - delay in milliseconds
  */
 export function exponentialDelay(retryNumber) {
-  return (Math.pow(2, retryNumber) * 1000) + Math.floor(Math.random() * 1000);
+  return (Math.pow(2, (retryNumber - 1)) * 1000) + Math.floor(Math.random() * 1000);
 }
 
 /**

--- a/es/index.js
+++ b/es/index.js
@@ -190,6 +190,7 @@ export default function axiosRetry(axios, defaultOptions) {
 
     if (shouldRetry) {
       currentState.retryCount++;
+      const delay = retryDelay(currentState.retryCount, error);
 
       // Axios fails merging this configuration to the default configuration because it has an issue
       // with circular structures: https://github.com/mzabriskie/axios/issues/370
@@ -198,11 +199,11 @@ export default function axiosRetry(axios, defaultOptions) {
       if (config.timeout && currentState.lastRequestTime) {
         const lastRequestDuration = Date.now() - currentState.lastRequestTime;
         // Minimum 1ms timeout (passing 0 or less to XHR means no timeout)
-        config.timeout = Math.max(config.timeout - lastRequestDuration, 1);
+        config.timeout = Math.max((config.timeout - lastRequestDuration) - delay, 1);
       }
 
       return new Promise((resolve) =>
-        setTimeout(() => resolve(axios(config)), retryDelay(currentState.retryCount, error))
+        setTimeout(() => resolve(axios(config)), delay)
       );
     }
 

--- a/es/index.js
+++ b/es/index.js
@@ -67,10 +67,10 @@ export function noDelay() {
 }
 
 /**
- * @param  {number} [retryNumber=0]
+ * @param  {number} retryNumber
  * @return {number} - delay in milliseconds
  */
-export function exponentialDelay(retryNumber = 0) {
+export function exponentialDelay(retryNumber) {
   return (Math.pow(2, retryNumber) * 1000) + Math.floor(Math.random() * 1000);
 }
 

--- a/es/index.js
+++ b/es/index.js
@@ -149,7 +149,7 @@ function fixConfig(axios, config) {
  * @param {Axios} axios An axios instance (the axios object or one created from axios.create)
  * @param {Object} [defaultOptions]
  * @param {number} [defaultOptions.retries=3] Number of retries
- * @param {number} [defaultOptions.retryCondition=isNetworkOrIdempotentRequestError]
+ * @param {Function} [defaultOptions.retryCondition=isNetworkOrIdempotentRequestError]
  *        A function to determine if the error can be retried
  */
 export default function axiosRetry(axios, defaultOptions) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,13 @@ export interface IAxiosRetryConfig {
    * 
    * @type {Function}
    */
-  retryCondition?: (error: axios.AxiosError) => boolean
+  retryCondition?: (error: axios.AxiosError) => boolean,
+  /**
+   * A callback to further control the delay between retry requests. By default there is no delay.
+   *
+   * @type {Function}
+   */
+  retryDelay?: (retryCount: number, error: axios.AxiosError) => number
 }
 
 export interface IAxiosRetry {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-retry",
-  "version": "3.0.2",
+  "version": "3.0.1",
   "author": "Rubén Norte <ruben.norte@softonic.com>",
   "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-retry",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Rubén Norte <ruben.norte@softonic.com>",
   "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
   "license": "Apache-2.0",

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -5,7 +5,9 @@ import {
   default as axiosRetry,
   isNetworkError,
   isSafeRequestError,
-  isIdempotentRequestError
+  isIdempotentRequestError,
+  noDelay,
+  exponentialDelay
 } from '../es/index';
 
 const NETWORK_ERROR = new Error('Some connection error');
@@ -367,5 +369,29 @@ describe('isIdempotentRequestError(error)', () => {
     errorResponse.code = 'ECONNABORTED';
     errorResponse.config = { method: 'get' };
     expect(isIdempotentRequestError(errorResponse)).toBe(false);
+  });
+});
+
+describe('noDelay', () => {
+  it('should return 1 for each call', () => {
+    expect(noDelay()).toBe(1);
+    expect(noDelay(1)).toBe(1);
+    expect(noDelay(10)).toBe(1);
+    expect(noDelay(1000)).toBe(1);
+  });
+});
+
+describe('exponentialDelay', () => {
+  it('should return exponential retry delay', () => {
+    function assertTime(retryNumber) {
+      const min = (Math.pow(2, retryNumber) * 1000);
+      const max = (Math.pow(2, retryNumber) * 1000) + 1000;
+
+      const time = exponentialDelay(retryNumber);
+
+      expect((time >= min && time <= max)).toBe(true);
+    }
+
+    [1, 2, 3, 4, 5].forEach(assertTime);
   });
 });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -374,8 +374,8 @@ describe('isIdempotentRequestError(error)', () => {
 describe('exponentialDelay', () => {
   it('should return exponential retry delay', () => {
     function assertTime(retryNumber) {
-      const min = (Math.pow(2, retryNumber) * 1000);
-      const max = (Math.pow(2, retryNumber) * 1000) + 1000;
+      const min = (Math.pow(2, (retryNumber - 1)) * 1000);
+      const max = (Math.pow(2, (retryNumber - 1)) * 1000) + 1000;
 
       const time = exponentialDelay(retryNumber);
 

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -6,7 +6,7 @@ import {
   isNetworkError,
   isSafeRequestError,
   isIdempotentRequestError,
-  exponentialDelay
+  exponentialDelay,
   isRetryableError
 } from '../es/index';
 

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -402,14 +402,14 @@ describe('isIdempotentRequestError(error)', () => {
 describe('exponentialDelay', () => {
   it('should return exponential retry delay', () => {
     function assertTime(retryNumber) {
-      const min = (Math.pow(2, (retryNumber - 1)) * 1000);
-      const max = (Math.pow(2, (retryNumber - 1)) * 1000) + 1000;
+      const min = (Math.pow(2, retryNumber) * 100);
+      const max = (Math.pow(2, retryNumber * 100) * 0.2);
 
       const time = exponentialDelay(retryNumber);
 
       expect((time >= min && time <= max)).toBe(true);
     }
 
-    [1, 2, 3, 4, 5].forEach(assertTime);
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach(assertTime);
   });
 });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -6,7 +6,6 @@ import {
   isNetworkError,
   isSafeRequestError,
   isIdempotentRequestError,
-  noDelay,
   exponentialDelay
 } from '../es/index';
 
@@ -369,15 +368,6 @@ describe('isIdempotentRequestError(error)', () => {
     errorResponse.code = 'ECONNABORTED';
     errorResponse.config = { method: 'get' };
     expect(isIdempotentRequestError(errorResponse)).toBe(false);
-  });
-});
-
-describe('noDelay', () => {
-  it('should return 1 for each call', () => {
-    expect(noDelay()).toBe(1);
-    expect(noDelay(1)).toBe(1);
-    expect(noDelay(10)).toBe(1);
-    expect(noDelay(1000)).toBe(1);
   });
 });
 


### PR DESCRIPTION
Fixes #3 by adding a `delayStrategy` option. By default `noDelay` is used, but a custom callback can be supplied which returns a value in milliseconds for the delay between requests.

I have also included a `exponentialDelay` function that can be passed in as the `delayStrategy` option that will provide exponential back-off for the delays between requests. The implementation and test for this has been taken from the [retry-request](https://github.com/stephenplusplus/retry-request) module by @stephenplusplus