### PR TITLE
add configuration for 'ECONNABORTED'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-retry",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "author": "Rubén Norte <ruben.norte@softonic.com>",
   "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
   "license": "Apache-2.0",


### PR DESCRIPTION
breaking changes 

fixes: #8 

1. refactoring isTimeoutError
2. removing isTimeoutError from  `isNetworkError` and `isRetryableError`
(which means that now `isNetworkError`,  `isSafeRequestError` and
`isIdempotentRequestError` are not checking for ```error.code !==
'ECONNABORTED'``` anymore
3. keep checking ```error.code !== 'ECONNABORTED'``` by default.
5. create new configuration option `retryTimeoutAborted` (false by default)
4. tests
