### PR TITLE
Added callback ability so that user has some idea of when retries are…

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -194,6 +194,9 @@ export default function axiosRetry(axios, defaultOptions) {
       currentState.retryCount++;
       const delay = retryDelay(currentState.retryCount, error);
 
+      if (typeof defaultOptions.retryCallback === 'function') {
+        defaultOptions.retryCallback(currentState.retryCount, error);
+      }
       // Axios fails merging this configuration to the default configuration because it has an issue
       // with circular structures: https://github.com/mzabriskie/axios/issues/370
       fixConfig(axios, config);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-retry",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Added a callback function to the config.

Should modify the documentation to edit the config table:

retryCallback 

Parameters are count and error where count is the current retry count number and the error was the error given on the previous try.

We check to ensure it exists and I tested with existence and non-existence to ensure proper behavior.  I am unsure why package-lock.json is committed but I saw the version update and so I committed it along just in case.
