### PR TITLE
Add option to maintain the timeout between retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ client
   });
 ```
 
-**Note:** the plugin interprets the request timeout as a global value, so it is not used for each retry but for the whole request lifecycle.
+**Note:** Unless `shouldResetTimeout` is set, the plugin interprets the request timeout as a global value, so it is not used for each retry but for the whole request lifecycle.
 
 ## Options
 
@@ -62,6 +62,7 @@ client
 | retries | `Number` | 3 | The number of times to retry before failing |
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
 | retryDelay | `Function` | `0` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
+| shouldResetTimeout | `Boolean` | false | Defines if the timeout should be reset between retries |
 
 ## Testing
 

--- a/es/index.js
+++ b/es/index.js
@@ -159,6 +159,8 @@ function fixConfig(axios, config) {
  * @param {Axios} axios An axios instance (the axios object or one created from axios.create)
  * @param {Object} [defaultOptions]
  * @param {number} [defaultOptions.retries=3] Number of retries
+ * @param {boolean} [defaultOptions.shouldResetTimeout=false]
+ *        Defines if the timeout should be reset between retries
  * @param {Function} [defaultOptions.retryCondition=isNetworkOrIdempotentRequestError]
  *        A function to determine if the error can be retried
  * @param {Function} [defaultOptions.retryDelay=noDelay]
@@ -182,7 +184,8 @@ export default function axiosRetry(axios, defaultOptions) {
     const {
       retries = 3,
       retryCondition = isNetworkOrIdempotentRequestError,
-      retryDelay = noDelay
+      retryDelay = noDelay,
+      shouldResetTimeout = false
     } = getRequestOptions(config, defaultOptions);
 
     const currentState = getCurrentState(config);
@@ -198,7 +201,7 @@ export default function axiosRetry(axios, defaultOptions) {
       // with circular structures: https://github.com/mzabriskie/axios/issues/370
       fixConfig(axios, config);
 
-      if (config.timeout && currentState.lastRequestTime) {
+      if (!shouldResetTimeout && config.timeout && currentState.lastRequestTime) {
         const lastRequestDuration = Date.now() - currentState.lastRequestTime;
         // Minimum 1ms timeout (passing 0 or less to XHR means no timeout)
         config.timeout = Math.max((config.timeout - lastRequestDuration) - delay, 1);

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,14 +4,21 @@ export interface IAxiosRetryConfig {
   /**
    * The number of times to retry before failing
    * default: 3
-   * 
+   *
    * @type {number}
    */
   retries?: number,
   /**
+   * Defines if the timeout should be reset between retries
+   * default: false
+   *
+   * @type {boolean}
+   */
+  shouldResetTimeout?: boolean,
+  /**
    * A callback to further control if a request should be retried. By default, it retries if the result did not have a response.
    * default: error => !error.response
-   * 
+   *
    * @type {Function}
    */
   retryCondition?: (error: axios.AxiosError) => boolean,

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -135,6 +135,23 @@ describe('axiosRetry(axios, { retries, retryCondition })', () => {
         });
       });
 
+      it('should reset the original `timeout` between requests', done => {
+        const client = axios.create();
+
+        setupResponses(client, [
+          () => nock('http://example.com').get('/test').delay(75).replyWithError(NETWORK_ERROR),
+          () => nock('http://example.com').get('/test').delay(75).replyWithError(NETWORK_ERROR),
+          () => nock('http://example.com').get('/test').reply(200)
+        ]);
+
+        axiosRetry(client, { retries: 3, shouldResetTimeout: true });
+
+        client.get('http://example.com/test', { timeout: 100 }).then(result => {
+          expect(result.status).toBe(200);
+          done();
+        });
+      });
+
       it('should reject with errors without a `config` property without retrying', done => {
         const client = axios.create();
 


### PR DESCRIPTION
Hey @rubennorte @jlopezxs 

I'd like to add an option to keep the timeout configured value between retries. As suggested in issue #24, I added a `shouldResetTimeout` option which defaults to `false` to keep the current behaviour.

Thanks!