### PR TITLE
Explicit return type on axiosRetry

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export interface IAxiosRetry {
   (
     axios: axios.AxiosStatic | axios.AxiosInstance,
     axiosRetryConfig?: IAxiosRetryConfig
-  )
+  ): void
 }
 
 declare const axiosRetry: IAxiosRetry


### PR DESCRIPTION
If the typescript compiler has the `noImplicitAny` flag enabled, you get an error: "Call signature, which lacks return-type annotation, implicitly has an 'any' return type."

This PR removes this error.

Fixes #41 