### PR TITLE
Feature/custom success response interceptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules
-npm-debug.log
 docs
 lib
+node_modules
+npm-debug.log
+.vscode

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ client
   });
 
 // Allows retries on status-code-200 responses to work around poorly-written APIs
-
-const shouldRetrySuccessResponse = (response) => {
-  return response.errorMessage && response.errorMessage.includes('too many requests');
+/**
+ * @returns {boolean}
+ **/
+const shouldRetrySuccessResponse = (responseBody) => {
+  return responseBody.errorMessage && responseBody.errorMessage.includes('too many requests');
 };
 
 axiosRetry(client, { shouldRetrySuccessResponse });
@@ -78,7 +80,7 @@ client.get('/test')  // Retries until shouldRetrySuccessResponse returns false o
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
 | retryDelay | `Function` | `function noDelay() { return 0; }` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
 | shouldResetTimeout | `Boolean` | false | Defines if the timeout should be reset between retries |
-| shouldRetrySuccessResponse | `Function` | `function shouldRetrySuccessResponse(response) { return false; }` | A callback to control if a response with a 200 status code should be retried.  Useful when you need to use APIs that send 200 status codes when an error status code (e.g. 429) is more appropriate. The function is passed the server's response.  |  
+| shouldRetrySuccessResponse | `Function` | `function shouldRetrySuccessResponse() { return false; }` | A function to control if a response with a 200 status code should be retried.  Useful when you need to use APIs that send 200 status codes when an error status code (e.g. 429) is more appropriate. The function is passed the server's response body (not the entire response; just the [HTTP response body](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#Body_2)).  |  
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ client
   .catch(error => { // The first request fails
     error !== undefined
   });
+
+// Allows retries on status-code-200 responses to work around poorly-written APIs
+
+const shouldRetrySuccessResponse = (response) => {
+  return response.errorMessage && response.errorMessage.includes('too many requests');
+};
+
+axiosRetry(client, { shouldRetrySuccessResponse });
+
+client.get('/test')  // Retries until shouldRetrySuccessResponse returns false or another no-retry condition is met
+  .then(result => {
+    result.data; // 'ok'
+  });
 ```
 
 **Note:** Unless `shouldResetTimeout` is set, the plugin interprets the request timeout as a global value, so it is not used for each retry but for the whole request lifecycle.
@@ -63,8 +76,9 @@ client
 | --- | --- | --- | --- |
 | retries | `Number` | `3` | The number of times to retry before failing. |
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
-| shouldResetTimeout | `Boolean` | false | Defines if the timeout should be reset between retries |
 | retryDelay | `Function` | `function noDelay() { return 0; }` | A callback to further control the delay between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
+| shouldResetTimeout | `Boolean` | false | Defines if the timeout should be reset between retries |
+| shouldRetrySuccessResponse | `Function` | `function shouldRetrySuccessResponse(response) { return false; }` | A callback to control if a response with a 200 status code should be retried.  Useful when you need to use APIs that send 200 status codes when an error status code (e.g. 429) is more appropriate. The function is passed the server's response.  |  
 
 ## Testing
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,12 @@ export interface IAxiosRetryConfig {
    */
   shouldResetTimeout?: boolean,
   /**
+   * A function to control if a response with a 200 status code should be retried.
+   * 
+   * @type {Function}
+   */
+  shouldRetrySuccessResponse?: (serverResponseBody: any) => boolean,
+  /**
    * A callback to further control if a request should be retried. By default, it retries if the result did not have a response.
    * default: error => !error.response
    *

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -89,7 +89,7 @@ describe('axiosRetry(axios, { retries, retryCondition })', () => {
 
         client.get('http://example.com/test').then(response => {
           expect(retryCount).toBe(1);
-          expect(response.data).toBe('this is a useful response');
+          expect(response.data).toEqual({ data: 'this is a useful response' });
           done();
         }, done.fail);
       });


### PR DESCRIPTION
**Why**
Sometimes a poorly-written API will return a status code 200 response instead of a status code 429 (too many requests) or some other, more-pertinent error code.

**What this PR does**
Adds an option `shouldRetrySuccessResponse` where the user can pass a function that checks the response and see if they want to retry.

For example, the user could tell axios-retry to retry the request for a response like this ({ errorMessage: 'Too many requests' }) with a function like this:
`function shouldRetrySuccessResponse(response) {
          return response.errorMessage && response.errorMessage.includes('Too many requests');
        }`

If the user doesn't supply a shouldRetrySuccessResponse option, the response is returned (& the request is not retried).
