### PR TITLE
bugfix: Cannot read property 'axios-retry' of undefined

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -172,6 +172,7 @@ function fixConfig(axios, config) {
  */
 export default function axiosRetry(axios, defaultOptions) {
   axios.interceptors.request.use(config => {
+    if (!config) return
     const currentState = getCurrentState(config);
     currentState.lastRequestTime = Date.now();
     return config;

--- a/es/index.js
+++ b/es/index.js
@@ -172,7 +172,9 @@ function fixConfig(axios, config) {
  */
 export default function axiosRetry(axios, defaultOptions) {
   axios.interceptors.request.use(config => {
-    if (!config) return
+    if (!config) {
+      return;
+    }
     const currentState = getCurrentState(config);
     currentState.lastRequestTime = Date.now();
     return config;


### PR DESCRIPTION
As a user of axios-retry, our site fequently report the error of "Cannot read property 'axios-retry' of undefined". After checking, I found it may happen in axios.interceptors.request.use() --> getCurrentState --> config[namespace]