### PR TITLE
export types for all functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,13 @@ interface IAxiosRetry {
   exponentialDelay(retryNumber: number): number;
 }
 
+export function isNetworkError(error: Error): boolean;
+export function isRetryableError(error: Error): boolean;
+export function isSafeRequestError(error: Error): boolean;
+export function isIdempotentRequestError(error: Error): boolean;
+export function isNetworkOrIdempotentRequestError(error: Error): boolean;
+export function exponentialDelay(retryNumber: number): number;
+
 declare namespace IAxiosRetry {
   export interface IAxiosRetryConfig {
     /**


### PR DESCRIPTION
The following will now be available for import
```
import axiosRetry, {
  IAxiosRetryConfig,
  exponentialDelay,
  isIdempotentRequestError,
  isNetworkError, 
  isNetworkOrIdempotentRequestError,
  isRetryableError,
  isSafeRequestError
} from 'axios-retry';
```