### PR TITLE
`onRetry(...)` Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ client
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
 | shouldResetTimeout | `Boolean` | false | Defines if the timeout should be reset between retries |
 | retryDelay | `Function` | `function noDelay() { return 0; }` | A callback to further control the delay in milliseconds between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
+| onRetry | `Function` | `function onRetry(retryCount, error, requestConfig) { return; }` | A callback to notify when a retry is about to occur. Useful for tracing. By default nothing will occur. The function is passed `retryCount`, `error`, and `requestConfig`. |
 
 ## Testing
 

--- a/es/index.js
+++ b/es/index.js
@@ -169,6 +169,8 @@ function fixConfig(axios, config) {
  *        A function to determine if the error can be retried
  * @param {Function} [defaultOptions.retryDelay=noDelay]
  *        A function to determine the delay between retry requests
+ * @param {Function} [defaultOptions.onRetry=()=>{}]
+ *        A function to get notified when a retry occurs
  */
 export default function axiosRetry(axios, defaultOptions) {
   axios.interceptors.request.use(config => {
@@ -189,7 +191,8 @@ export default function axiosRetry(axios, defaultOptions) {
       retries = 3,
       retryCondition = isNetworkOrIdempotentRequestError,
       retryDelay = noDelay,
-      shouldResetTimeout = false
+      shouldResetTimeout = false,
+      onRetry = () => {}
     } = getRequestOptions(config, defaultOptions);
 
     const currentState = getCurrentState(config);
@@ -211,6 +214,8 @@ export default function axiosRetry(axios, defaultOptions) {
       }
 
       config.transformRequest = [data => data];
+
+      onRetry(currentState.retryCount, error, config);
 
       return new Promise(resolve => setTimeout(() => resolve(axios(config)), delay));
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,12 @@ declare namespace IAxiosRetry {
      * @type {Function}
      */
     retryDelay?: (retryCount: number, error: axios.AxiosError) => number
+    /**
+     * A callback to get notified when a retry occurs, the number of times it has occurre, and the error
+     *
+     * @type {Function}
+     */
+    onRetry?: (retryCount: number, error: axios.AxiosError, requestConfig: axios.AxiosRequestConfig) => void
   }
 }
 


### PR DESCRIPTION
Added an `onRetry(retryCount: number, error: axios.AxiosError, requestConfig: axios.AxiosRequestConfig) => void` configuration function that acts as a notifier when a retry is happening. I have this use-case in my own app that requires tracing when a retry happens. The function provides the retry amount, the error that triggered the retry, and the requestConfig from the failed request.

