### PR TITLE
Make retryCondition accept a promise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ declare namespace IAxiosRetry {
      *
      * @type {Function}
      */
-    retryCondition?: (error: axios.AxiosError) => boolean,
+    retryCondition?: (error: axios.AxiosError) => boolean | Promise<boolean>,
     /**
      * A callback to further control the delay between retry requests. By default there is no delay.
      *


### PR DESCRIPTION
**Status Quo:**

If you have a call that fails with an 401 because of you cannot use axios-retry for this, since there is no way to tell how long a silent token refresh will take (so we could do it with retry-delay) or if it works at all (so we know what to put in retryCondition).

**Solution:**

The logical choice is, that `retryCondition` would optionally accept a function that returns a promise instead of boolean. And only if that succeeds (and returns true), we do the retry. That way we could easily accompany such use cases (as happened already, example with #56).

Since no one asked for this PR, I still needed it, so have done it. If there is something you would like to have changed, I will gladly do it, so we can move back to the original node module instead of loading it via fork.