### PR TITLE
Enhance readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ client
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| retries | `Number` | `3` | The number of times to retry before failing. |
+| retries | `Number` | `3` | The number of times to retry before failing. 1 = One retry after first failure |
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
 | shouldResetTimeout | `Boolean` | false | Defines if the timeout should be reset between retries |
 | retryDelay | `Function` | `function noDelay() { return 0; }` | A callback to further control the delay in milliseconds between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |


### PR DESCRIPTION
I was not sure whereas the retry=1 would retry one time or just considering the first call as the first retry already. I checked the code and updated the documentation in order to  disambiguates this particular case.

I'm totally open to a better wording if you have suggestions. 