### PR TITLE
Extended AxiosRequestConfig with "retryCount" property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,13 @@ declare namespace IAxiosRetry {
      */
     retries?: number,
     /**
+     * The number of times the request has already failed
+     * default: 0
+     *
+     * @type {number}
+     */    
+    retryCount?: number,
+    /**
      * Defines if the timeout should be reset between retries
      * default: false
      *


### PR DESCRIPTION
I logged `axiosError.config['axios-retry']` in my code and noticed that there is a `retryCount` which tells me how often my request failed already.