### PR TITLE
fix: allow default import from cjs (typescript)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,4 @@
-module.exports = require('./lib/cjs/index').default;
+const axiosRetry = require('./lib/cjs/index').default;
+
+module.exports = axiosRetry;
+module.exports.default = axiosRetry;


### PR DESCRIPTION
Allow default import when using typescript module="CommonJS"