### PR TITLE
fix: add package.json to exports for react-native-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     ".": {
       "import": "./lib/esm/index.js",
       "require": "./index.js"
-    }
+    },
+    "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
### Context

This resolves #184 .

Recent updates to the project were causing warnings to be thrown because `react-native-cli` couldn't resolve the `package.json` file.  This came down to the file needing to be added to the exports for the module so it could be properly resolved.  Example of how `react-native-cli` is loading the modules for validation [here](https://github.com/react-native-community/cli/blob/2dbb1c8b9ae63aca4e48cd0922c61e250691f9d7/packages/cli/src/tools/config/index.ts#L118), with the important bit being [here](https://github.com/react-native-community/cli/blob/2dbb1c8b9ae63aca4e48cd0922c61e250691f9d7/packages/tools/src/resolveNodeModuleDir.ts#L6) where it resolves the `package.json` file from the module.

### Steps to Reproduce

1. Setup empty repo
   ```bash
   yarn init -y
   yarn add -D axios-retry
   touch index.js
   ```
1. Add the following content to the `index.js` file to test the error
   ```js
   const path = require("path");
   
   let moduleDir;
   try {
     moduleDir = path.dirname(
       require.resolve(path.join("axios-retry", "package.json"), {
         paths: [path.join(__dirname, "node_modules")],
       })
     );
   } catch (e) {
     console.error("unable to locate module dir, reason:", e);
     return;
   }
   
   console.log("found module dir:", moduleDir);
   ```
1. Run the following and confirm an error is logged with the following
   ```bash
   node index.js
   ```
   ```
   unable to locate module dir, reason: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in node_modules/axios-retry/package.json
       at throwExportsNotFound (internal/modules/esm/resolve.js:285:9)
       at packageExportsResolve (internal/modules/esm/resolve.js:508:3)
       at resolveExports (internal/modules/cjs/loader.js:424:36)
       at Function.Module._findPath (internal/modules/cjs/loader.js:464:31)
       at Function.Module._resolveFilename (internal/modules/cjs/loader.js:802:27)
       at Function.resolve (internal/modules/cjs/helpers.js:80:19)
       at Object.<anonymous> (/Users/leezumstein/dev/forks/test/index.js:6:13)
       at Module._compile (internal/modules/cjs/loader.js:999:30)
       at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
       at Module.load (internal/modules/cjs/loader.js:863:32) {
   code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
   }
   ```
1. Apply the change to the `exports` in the `package.json` present on the PR
1. Re run the following and confirm the error is gone
   ```bash
   node index.js
   ```
   ```
   found module dir: <resolved path to axios-retry>
   ```