### PR TITLE
Mark request interceptor as synchronous

### DIFF
--- a/es/index.mjs
+++ b/es/index.mjs
@@ -198,7 +198,7 @@ export default function axiosRetry(axios, defaultOptions) {
     const currentState = getCurrentState(config);
     currentState.lastRequestTime = Date.now();
     return config;
-  });
+  }, null, { synchronous: true });
 
   axios.interceptors.response.use(null, async (error) => {
     const { config } = error;


### PR DESCRIPTION
Axios recently added an option to specify whether a request interceptor is synchronous. See https://github.com/axios/axios/pull/2702.

This enables requests to be sent as soon as possible, instead of waiting for unnecessary microtasks to be run (which might be blocked behind other main thread work). 