### PR TITLE
Add space in readme code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ axios.get('http://example.com/test') // The first request fails and the second r
   });
 
 // Exponential back-off retry delay between requests
-axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay});
+axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay });
 
 // Custom retry delay
 axiosRetry(axios, { retryDelay: (retryCount) => {


### PR DESCRIPTION
This doesn't really matter, but I noticed it so I figured
I'd put up a fix for it.