### PR TITLE
fix: Add types to exports object to allow TypeScript 4.7 + Node 16 to properly resolve typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./lib/esm/index.js",
       "require": "./index.js"
     },


### PR DESCRIPTION
Add types export to exports field so TypeScript 4.7 is able to the the types when using the module resolution for Node 16+.

The types inside the exports object has to be first for TypeScript to be happy (see this issue: https://github.com/microsoft/TypeScript/issues/46334).