### PR TITLE
feat: add delayFactor param to exponentialDelay

### DIFF
--- a/es/index.mjs
+++ b/es/index.mjs
@@ -71,11 +71,14 @@ function noDelay() {
 }
 
 /**
+ * Set delayFactor 1000 for an exponential delay to occur on the order
+ * of seconds
  * @param  {number} [retryNumber=0]
+ * @param  {number} [delayFactor=100] milliseconds
  * @return {number} - delay in milliseconds
  */
-export function exponentialDelay(retryNumber = 0) {
-  const delay = Math.pow(2, retryNumber) * 1000;
+export function exponentialDelay(retryNumber = 0, delayFactor = 100) {
+  const delay = Math.pow(2, retryNumber) * delayFactor;
   const randomSum = delay * 0.2 * Math.random(); // 0-20% of the delay
   return delay + randomSum;
 }

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -75,7 +75,7 @@ function noDelay() {
  * @return {number} - delay in milliseconds
  */
 export function exponentialDelay(retryNumber = 0) {
-  const delay = Math.pow(2, retryNumber) * 100;
+  const delay = Math.pow(2, retryNumber) * 1000;
   const randomSum = delay * 0.2 * Math.random(); // 0-20% of the delay
   return delay + randomSum;
 }

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -226,7 +226,7 @@ export default function axiosRetry(axios, defaultOptions) {
 
     if (await shouldRetry(retries, retryCondition, currentState, error)) {
       currentState.retryCount += 1;
-      const delay = retryDelay(currentState.retryCount);
+      const delay = retryDelay(currentState.retryCount, error);
 
       // Axios fails merging this configuration to the default configuration because it has an issue
       // with circular structures: https://github.com/mzabriskie/axios/issues/370

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -226,7 +226,7 @@ export default function axiosRetry(axios, defaultOptions) {
 
     if (await shouldRetry(retries, retryCondition, currentState, error)) {
       currentState.retryCount += 1;
-      const delay = retryDelay(currentState.retryCount, error);
+      const delay = retryDelay(currentState.retryCount);
 
       // Axios fails merging this configuration to the default configuration because it has an issue
       // with circular structures: https://github.com/mzabriskie/axios/issues/370

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -74,10 +74,11 @@ function noDelay() {
  * Set delayFactor 1000 for an exponential delay to occur on the order
  * of seconds
  * @param  {number} [retryNumber=0]
+ * @param  {Error}  error - unused; for existing API of retryDelay callback
  * @param  {number} [delayFactor=100] milliseconds
  * @return {number} - delay in milliseconds
  */
-export function exponentialDelay(retryNumber = 0, delayFactor = 100) {
+export function exponentialDelay(retryNumber = 0, error, delayFactor = 100) {
   const delay = Math.pow(2, retryNumber) * delayFactor;
   const randomSum = delay * 0.2 * Math.random(); // 0-20% of the delay
   return delay + randomSum;

--- a/spec/index.spec.mjs
+++ b/spec/index.spec.mjs
@@ -642,6 +642,19 @@ describe('exponentialDelay', () => {
 
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach(assertTime);
   });
+
+  it('should change delay time when specifying delay factor', () => {
+    function assertTime(retryNumber) {
+      const min = Math.pow(2, retryNumber) * 1000;
+      const max = Math.pow(2, retryNumber * 1000) * 0.2;
+
+      const time = exponentialDelay(retryNumber, 1000);
+
+      expect(time >= min && time <= max).toBe(true);
+    }
+
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach(assertTime);
+  });
 });
 
 describe('isRetryableError(error)', () => {

--- a/spec/index.spec.mjs
+++ b/spec/index.spec.mjs
@@ -648,7 +648,7 @@ describe('exponentialDelay', () => {
       const min = Math.pow(2, retryNumber) * 1000;
       const max = Math.pow(2, retryNumber * 1000) * 0.2;
 
-      const time = exponentialDelay(retryNumber, 1000);
+      const time = exponentialDelay(retryNumber, null, 1000);
 
       expect(time >= min && time <= max).toBe(true);
     }


### PR DESCRIPTION
## Issue

Current implementation of `exponentialDelay` results in retries based on the order of 100ms – i.e. 100ms, 200ms, 400ms, 800ms, etc. This is in contrast with the [Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff) link found in the README which suggests 1s, 2s, 4s, 8s, etc.

## Solution

Add `delayFactor` param which can be passed 1000. Defaults to 100 as to keep the current behavior.

## Related

* addresses #87 
* updated (not-stale) dupe of #111 