### PR TITLE
Make `onRetry` callback compatible with Promises

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Jasmine-Node Debugging",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceRoot}/node_modules/jasmine/bin/jasmine.js",
+            "request": "launch",
+            "type": "node",
+            "args": [
+                "--config=./spec/support/jasmine.json",
+                "./spec/index.spec.mjs"
+            ]
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.3.2] - 2022-10-20
+
+- Updated `onRetry` to be compatible with asynchronous callback
+
 ## [3.3.1] - 2022-06-29
 
 - Security updates

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Clone the repository and execute:
 npm test
 ```
 
+### Debugging
+
+install the following package in VS Code
+
+```
+DmitriyMuraviov.vscode-jasmine-test-runner
+```
+
+The VS Code configuration should work automatically, else press Ctrl+Shift+P and type `Developer: Reload Window`, which will reload all the installed extensions
+
 ## Contribute
 
 1. Fork it: `git clone https://github.com/softonic/axios-retry.git`

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -237,12 +237,7 @@ export default function axiosRetry(axios, defaultOptions) {
 
       config.transformRequest = [(data) => data];
 
-      // Check if promise or regular void
-      if (typeof onRetry === 'object') {
-        await onRetry(currentState.retryCount, error, config);
-      } else {
-        onRetry(currentState.retryCount, error, config);
-      }
+      await onRetry(currentState.retryCount, error, config);
 
       return new Promise((resolve) => setTimeout(() => resolve(axios(config)), delay));
     }

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -237,7 +237,7 @@ export default function axiosRetry(axios, defaultOptions) {
 
       config.transformRequest = [(data) => data];
 
-      onRetry(currentState.retryCount, error, config);
+      await onRetry(currentState.retryCount, error, config);
 
       return new Promise((resolve) => setTimeout(() => resolve(axios(config)), delay));
     }

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -237,7 +237,12 @@ export default function axiosRetry(axios, defaultOptions) {
 
       config.transformRequest = [(data) => data];
 
-      await onRetry(currentState.retryCount, error, config);
+      // Check if promise or regular void
+      if (typeof onRetry === 'object') {
+        await onRetry(currentState.retryCount, error, config);
+      } else {
+        onRetry(currentState.retryCount, error, config);
+      }
 
       return new Promise((resolve) => setTimeout(() => resolve(axios(config)), delay));
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ declare namespace IAxiosRetry {
      *
      * @type {Function}
      */
-    onRetry?: (retryCount: number, error: axios.AxiosError, requestConfig: axios.AxiosRequestConfig) => void
+    onRetry?: (retryCount: number, error: axios.AxiosError, requestConfig: axios.AxiosRequestConfig) => void | Promise<void>
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,7 @@ declare namespace IAxiosRetry {
      * A callback to get notified when a retry occurs, the number of times it has occurre, and the error
      *
      * @type {Function}
+     * @remark By default HTTP/401 are not retried, if you need to update a token bearer, make sure to mention `retryCondition: () => true`
      */
     onRetry?: (retryCount: number, error: axios.AxiosError, requestConfig: axios.AxiosRequestConfig) => void | Promise<void>
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "axios-retry",
-  "version": "3.3.1",
+  "name": "@coin-miles/axios-retry",
+  "version": "3.3.4",
   "author": "Rubén Norte <ruben.norte@softonic.com>",
   "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@coin-miles/axios-retry",
-  "version": "3.3.4",
-  "author": "Rubén Norte <ruben.norte@softonic.com>",
+  "version": "3.3.5",
+  "author": "Mathieu Auclair <mathieu@coinmiles.io>, Rubén Norte <ruben.norte@softonic.com>",
   "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/softonic/axios-retry",
+  "homepage": "https://github.com/coinmiles-technology/axios-retry",
   "files": [
     "es",
     "lib",
@@ -54,10 +54,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/softonic/axios-retry.git"
+    "url": "git+https://github.com/coinmiles-technology/axios-retry.git"
   },
   "bugs": {
-    "url": "https://github.com/softonic/axios-retry/issues"
+    "url": "https://github.com/coinmiles-technology/axios-retry/issues"
   },
   "typings": "./index.d.ts",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@coin-miles/axios-retry",
-  "version": "3.3.5",
-  "author": "Mathieu Auclair <mathieu@coinmiles.io>, Rubén Norte <ruben.norte@softonic.com>",
+  "name": "axios-retry",
+  "version": "3.3.2",
+  "author": "Rubén Norte <ruben.norte@softonic.com>",
   "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/coinmiles-technology/axios-retry",
+  "homepage": "https://github.com/softonic/axios-retry",
   "files": [
     "es",
     "lib",
@@ -54,10 +54,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coinmiles-technology/axios-retry.git"
+    "url": "git+https://github.com/softonic/axios-retry.git"
   },
   "bugs": {
-    "url": "https://github.com/coinmiles-technology/axios-retry/issues"
+    "url": "https://github.com/softonic/axios-retry/issues"
   },
   "typings": "./index.d.ts",
   "main": "index.js",

--- a/spec/index.spec.mjs
+++ b/spec/index.spec.mjs
@@ -7,7 +7,8 @@ import axiosRetry, {
   isIdempotentRequestError,
   exponentialDelay,
   isRetryableError
-} from '../es/index';
+  // eslint-disable-next-line import/extensions
+} from '../es/index.mjs';
 
 const NETWORK_ERROR = new Error('Some connection error');
 NETWORK_ERROR.code = 'ECONNRESET';


### PR DESCRIPTION
Hi there! 

I updated the `onRetry` callback to accept Promises both in JS and in TS. This was an issue for us, in our case, we are required to generate a bearer token using an asynchronous HTTPS request whenever there's a response with HTTP/401 (which just means the bearer token is expired ), we then update the authorization header with the request result. I added a test scenario where I do just the same thing.

I also added documentation & instruction on how to run/debug the project! Fixing the issue I previously created: #215 

Let me know if there's anything not matching your guidelines! 

The package is available here: https://www.npmjs.com/package/@coin-miles/axios-retry

Thanks! Looking forward to do more contributions!