### PR TITLE
feat: Allow to eject interceptors added by `axiosRetry`

### DIFF
--- a/es/index.mjs
+++ b/es/index.mjs
@@ -199,15 +199,17 @@ async function shouldRetry(retries, retryCondition, currentState, error) {
  *        A function to determine the delay between retry requests
  * @param {Function} [defaultOptions.onRetry=()=>{}]
  *        A function to get notified when a retry occurs
+ * @return {{ requestInterceptorId: number, responseInterceptorId: number }}
+ *        The ids of the interceptors added to the request and to the response (so they can be ejected at a later time)
  */
 export default function axiosRetry(axios, defaultOptions) {
-  axios.interceptors.request.use((config) => {
+  const requestInterceptorId = axios.interceptors.request.use((config) => {
     const currentState = getCurrentState(config);
     currentState.lastRequestTime = Date.now();
     return config;
   });
 
-  axios.interceptors.response.use(null, async (error) => {
+  const responseInterceptorId = axios.interceptors.response.use(null, async (error) => {
     const { config } = error;
 
     // If we have no information to retry the request
@@ -251,6 +253,8 @@ export default function axiosRetry(axios, defaultOptions) {
 
     return Promise.reject(error);
   });
+
+  return { requestInterceptorId, responseInterceptorId };
 }
 
 // Compatibility with CommonJS

--- a/spec/index.spec.mjs
+++ b/spec/index.spec.mjs
@@ -688,3 +688,25 @@ describe('isRetryableError(error)', () => {
     expect(isRetryableError(errorResponse)).toBe(false);
   });
 });
+
+describe('axiosRetry interceptors', () => {
+  it('should be able to successfully eject interceptors added by axiosRetry', () => {
+    const client = axios.create();
+
+    expect(client.interceptors.request.handlers.length).toBe(0);
+    expect(client.interceptors.response.handlers.length).toBe(0);
+
+    const { requestInterceptorId, responseInterceptorId } = axiosRetry(client);
+
+    expect(client.interceptors.request.handlers.length).toBe(1);
+    expect(client.interceptors.response.handlers.length).toBe(1);
+    expect(client.interceptors.request.handlers[0]).not.toBe(null);
+    expect(client.interceptors.response.handlers[0]).not.toBe(null);
+
+    client.interceptors.request.eject(requestInterceptorId);
+    client.interceptors.response.eject(responseInterceptorId);
+
+    expect(client.interceptors.request.handlers[0]).toBe(null);
+    expect(client.interceptors.response.handlers[0]).toBe(null);
+  });
+});


### PR DESCRIPTION
This should fix #231 

The function `axiosRetry` now returns the two interceptor ids that were added to the request and response, allowing latter eject of them.

A test were added to assure that the interceptors added by `axiosRetry` can be successfully ejected.