### PR TITLE
feat: Proposal implement onMaxRetryTimesExceeded to allow user to emit a custom error after retries done

### DIFF
--- a/es/index.mjs
+++ b/es/index.mjs
@@ -146,6 +146,12 @@ async function shouldRetry(retries, retryCondition, currentState, error) {
   return shouldRetryOrPromise;
 }
 
+const handleMaxRetryTimesExceeded = (defaultOptions, currentState, retries, error) => {
+  if (defaultOptions.onMaxRetryTimesExceeded && currentState.retryCount >= retries) {
+    defaultOptions.onMaxRetryTimesExceeded(error, currentState.retryCount);
+  }
+};
+
 /**
  * Adds response interceptors to an axios instance to retry requests failed due to network issues
  *
@@ -250,6 +256,8 @@ export default function axiosRetry(axios, defaultOptions) {
 
       return new Promise((resolve) => setTimeout(() => resolve(axios(config)), delay));
     }
+
+    handleMaxRetryTimesExceeded(defaultOptions, currentState, retries, error);
 
     return Promise.reject(error);
   });

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,13 @@ declare namespace IAxiosRetry {
      * @type {Function}
      */
     onRetry?: (retryCount: number, error: axios.AxiosError, requestConfig: axios.AxiosRequestConfig) => void
+    /**
+     * After all the retries are failed, this callback will be called with the last error
+     * before throwing the error.
+     * 
+     * * @type {Function}
+     */
+    onMaxRetryTimesExceeded?: (error: axios.AxiosError, retryCount: number) => void
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axios-retry",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "axios-retry",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-retry",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "author": "Rubén Norte <ruben.norte@softonic.com>",
   "description": "Axios plugin that intercepts failed requests and retries them whenever posible.",
   "license": "Apache-2.0",

--- a/spec/index.spec.mjs
+++ b/spec/index.spec.mjs
@@ -417,6 +417,36 @@ describe('axiosRetry(axios, { retries, retryDelay })', () => {
   });
 });
 
+describe('axiosRetry(axios, { onMaxRetryTimesExceeded })', () => {
+  const customError = new Error('CustomErrorAfterMaxRetryTimesExceeded');
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  describe('when the onMaxRetryTimesExceeded is handled', () => {
+    it('should reject with the custom error', (done) => {
+      const client = axios.create();
+      setupResponses(client, [() => nock('http://example.com').get('/test').reply(502, 'Failed!')]);
+
+      const onMaxRetryTimesExceeded = () => {
+        throw customError;
+      };
+
+      axiosRetry(client, {
+        retries: 2,
+        onMaxRetryTimesExceeded
+      });
+
+      client.get('http://example.com/test').then(done.fail, (error) => {
+        expect(error).toEqual(customError);
+        done();
+      });
+    });
+  });
+});
+
 describe('axiosRetry(axios, { retries, onRetry })', () => {
   afterEach(() => {
     nock.cleanAll();


### PR DESCRIPTION
### Why:
Sometimes we need to treat retry error in HTTP communications as a step of big flow we should follow, for example to classify a http transaction to be retried again by another service in the background. 

### Solution:
For this reason I am creating the callback onMaxRetryTimesExceeded to be called after the last retry was called. That way we can trigger for example a custom Exception to classify the transaction.

### Example of Use:
<img width="401" alt="image" src="https://github.com/softonic/axios-retry/assets/48806218/38546e4d-1e0e-4709-8f2d-aedc4608006a">
