### PR TITLE
fix: ESM default import `This expression is not callable`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,27 +1,24 @@
-import * as axios from 'axios'
+import * as axios from 'axios';
 
-interface IAxiosRetry {
-  (
-    axios: axios.AxiosStatic | axios.AxiosInstance,
-    axiosRetryConfig?: IAxiosRetry.IAxiosRetryConfig
-  ): IAxiosRetry.IAxiosRetryReturn;
-
-  isNetworkError(error: Error): boolean;
-  isRetryableError(error: Error): boolean;
-  isSafeRequestError(error: Error): boolean;
-  isIdempotentRequestError(error: Error): boolean;
-  isNetworkOrIdempotentRequestError(error: Error): boolean;
-  exponentialDelay(retryNumber?: number, error?: Error, delayFactor?: number): number;
-}
-
-export function isNetworkError(error: Error): boolean;
-export function isRetryableError(error: Error): boolean;
-export function isSafeRequestError(error: Error): boolean;
-export function isIdempotentRequestError(error: Error): boolean;
-export function isNetworkOrIdempotentRequestError(error: Error): boolean;
-export function exponentialDelay(retryNumber?: number, error?: Error, delayFactor?: number): number;
+export = IAxiosRetry;
+export as namespace axiosRetry;
+declare const IAxiosRetry: IAxiosRetry.AxiosRetry;
 
 declare namespace IAxiosRetry {
+  export interface AxiosRetry {
+    (
+      axios: axios.AxiosStatic | axios.AxiosInstance,
+      axiosRetryConfig?: IAxiosRetryConfig
+    ): IAxiosRetryReturn;
+
+    isNetworkError(error: Error): boolean;
+    isRetryableError(error: Error): boolean;
+    isSafeRequestError(error: Error): boolean;
+    isIdempotentRequestError(error: Error): boolean;
+    isNetworkOrIdempotentRequestError(error: Error): boolean;
+    exponentialDelay(retryNumber?: number, error?: Error, delayFactor?: number): number;
+  }
+
   export interface IAxiosRetryConfig {
     /**
      * The number of times to retry before failing
@@ -29,33 +26,37 @@ declare namespace IAxiosRetry {
      *
      * @type {number}
      */
-    retries?: number,
+    retries?: number;
     /**
      * Defines if the timeout should be reset between retries
      * default: false
      *
      * @type {boolean}
      */
-    shouldResetTimeout?: boolean,
+    shouldResetTimeout?: boolean;
     /**
      * A callback to further control if a request should be retried.
      * default: it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE).
      *
      * @type {Function}
      */
-    retryCondition?: (error: axios.AxiosError) => boolean | Promise<boolean>,
+    retryCondition?: (error: axios.AxiosError) => boolean | Promise<boolean>;
     /**
      * A callback to further control the delay between retry requests. By default there is no delay.
      *
      * @type {Function}
      */
-    retryDelay?: (retryCount: number, error: axios.AxiosError) => number
+    retryDelay?: (retryCount: number, error: axios.AxiosError) => number;
     /**
      * A callback to get notified when a retry occurs, the number of times it has occurre, and the error
      *
      * @type {Function}
      */
-    onRetry?: (retryCount: number, error: axios.AxiosError, requestConfig: axios.AxiosRequestConfig) => void
+    onRetry?: (
+      retryCount: number,
+      error: axios.AxiosError,
+      requestConfig: axios.AxiosRequestConfig
+    ) => void;
   }
 
   export interface IAxiosRetryReturn {
@@ -74,15 +75,8 @@ declare namespace IAxiosRetry {
   }
 }
 
-declare const axiosRetry: IAxiosRetry;
-
-export type IAxiosRetryConfig = IAxiosRetry.IAxiosRetryConfig;
-export type IAxiosRetryReturn = IAxiosRetry.IAxiosRetryReturn;
-
-export default axiosRetry;
-
 declare module 'axios' {
   export interface AxiosRequestConfig {
-    'axios-retry'?: IAxiosRetryConfig;
+    'axios-retry'?: IAxiosRetry.IAxiosRetryConfig;
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "bugs": {
     "url": "https://github.com/softonic/axios-retry/issues"
   },
-  "typings": "./index.d.ts",
+  "types": "./index.d.ts",
   "main": "index.js",
   "module": "lib/esm/index.js",
   "exports": {


### PR DESCRIPTION
This ought to fix https://github.com/softonic/axios-retry/issues/228

ESM seems incompatible in CommonJS PJs with default export (see https://github.com/microsoft/TypeScript/issues/52086).
I think there are two solutions to make TypeScript types compatible with both CommonJS and ESM.

1. Create a new type definition for ESM
reference: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
2. Change type definitions to support both CommonJS and ESM

Case `1`, I would make a copy of the current `index.d.ts`, rename the file to `index.d.mts`, and change package.json as follows.
```json:package.json
  "exports": {
    ".": {
      "import": {
        "types": "./index.d.mts",
        "default": "./lib/esm/index.js"
      },
      "require": {
        "types": "./index.d.ts",
        "default": "./index.js"
      }
    },
    "./package.json": "./package.json"
  }
```

However, I think this is redundant and low-maintainability because we have to manage two type definitions, so I tried to modify it in the second way(Case `2`).

### Explanation of this modification

- By setting `export = `, both CommonJS and ESM are supported.
I do not expect any impact on existing CommonJS implementations of TypeScript developers. Originally, when using `export default`, as described in  [Default Exports](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports), the `esModuleInterop` option must be used, and testing has confirmed that it can be compiled with this setting.
Also, testing confirms that the project can be compiled with the project in the ESM configuration.

- dtslint and index.test-d.ts
I'm adding dtslint and type definition tests to this project to match the axios project setup.
The settings in tsconfig.json and tslint.json for dtslint are copied almost directly from axios, so there should be no problems.
I think it should be included because the addition of dtslint allows us to safely update type definitions.
(More than half of the modifications to existing type definitions is based on dtslint checks.)

For this change, I refer to the following
- https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
- https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports
- https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html
- https://www.typescriptlang.org/docs/handbook/modules.html