### PR TITLE
feat: onRetry support for async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ client
 | retryCondition | `Function` | `isNetworkOrIdempotentRequestError` | A callback to further control if a request should be retried.  By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE). |
 | shouldResetTimeout | `Boolean` | false | Defines if the timeout should be reset between retries |
 | retryDelay | `Function` | `function noDelay() { return 0; }` | A callback to further control the delay in milliseconds between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
-| onRetry | `Function` | `function onRetry(retryCount, error, requestConfig) { return; }` | A callback to notify when a retry is about to occur. Useful for tracing. By default nothing will occur. The function is passed `retryCount`, `error`, and `requestConfig`. |
+| onRetry | `Function` | `function onRetry(retryCount, error, requestConfig) { return; }` | A callback to notify when a retry is about to occur. Useful for tracing and you can any async process for example refresh a token on 401. By default nothing will occur. The function is passed `retryCount`, `error`, and `requestConfig`. |
 
 ## Testing
 

--- a/es/index.mjs
+++ b/es/index.mjs
@@ -248,7 +248,7 @@ export default function axiosRetry(axios, defaultOptions) {
 
       config.transformRequest = [(data) => data];
 
-      onRetry(currentState.retryCount, error, config);
+      await onRetry(currentState.retryCount, error, config);
 
       return new Promise((resolve) => setTimeout(() => resolve(axios(config)), delay));
     }


### PR DESCRIPTION
This PR solves the https://github.com/softonic/axios-retry/issues/236.

Since `await` is simply ignored for synchronous functions, this change should not affect existing functionality.

Added test to verify that onRetry works as expected even when it returns a `promise`.