### PR TITLE
feat: expose axios-retry options in error object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,21 @@ declare namespace IAxiosRetry {
     ) => void;
   }
 
+  export interface IAxiosRetryConfigExtended extends IAxiosRetryConfig {
+    /**
+     * The number of times the request was retried
+     *
+     * @type {number}
+     */
+    retryCount?: number;
+    /**
+     * The last time the request was retried (timestamp in milliseconds)
+     *
+     * @type {number}
+     */
+    lastRequestTime?: number;
+  }
+
   export interface IAxiosRetryReturn {
     /**
      * The interceptorId for the request interceptor
@@ -77,6 +92,6 @@ declare namespace IAxiosRetry {
 
 declare module 'axios' {
   export interface AxiosRequestConfig {
-    'axios-retry'?: IAxiosRetry.IAxiosRetryConfig;
+    'axios-retry'?: IAxiosRetry.IAxiosRetryConfigExtended;
   }
 }

--- a/spec/index.spec.mjs
+++ b/spec/index.spec.mjs
@@ -86,6 +86,8 @@ describe('axiosRetry(axios, { retries, retryCondition })', () => {
 
         client.get('http://example.com/test').then((result) => {
           expect(result.status).toBe(200);
+          expect(result.config[namespace].retries).toBe(1);
+          expect(result.config[namespace].retryCount).toBe(1);
           done();
         }, done.fail);
       });


### PR DESCRIPTION
This PR aims to expose the plugin options inside error objects. This should close https://github.com/softonic/axios-retry/issues/166