### PR TITLE
fix: has no call signatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "pretest": "npm run lint",
     "test": "ts-node --project tsconfig-cjs.json node_modules/jasmine/bin/jasmine",
     "prebuild": "npm run test",
-    "build": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
-    "postbuild": "tsc --declaration --emitDeclarationOnly --outDir dist/",
+    "build": "rm -fr dist/* && npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc -p tsconfig.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
+    "build:cjs": "tsc -p tsconfig-cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
     "prerelease": "npm run build",
     "release": "npm version -m \"New version: %s\"",
     "postrelease": "npm run push && npm publish",
@@ -59,14 +60,19 @@
   "bugs": {
     "url": "https://github.com/softonic/axios-retry/issues"
   },
-  "types": "dist/index.d.ts",
+  "types": "dist/cjs/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
     },
     "./package.json": "./package.json"
   }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "src",
-    "declaration": false,
+    "declaration": true,
     "esModuleInterop": true,
     "inlineSourceMap": false,
     "lib": ["esnext"],


### PR DESCRIPTION
The problem that occurred previously is occurring again.
I think we should do exports for both esm and cjs.

The same support is available in repositories such as [stripe-node](https://github.com/stripe/stripe-node).

Details will be as per the PR below.

https://github.com/softonic/axios-retry/pull/241

### test

- cjs: no error
![image](https://github.com/softonic/axios-retry/assets/79501292/500ad499-6235-4842-a610-72700fe3f271)
- esm: no error
![image](https://github.com/softonic/axios-retry/assets/79501292/3c0b49d3-b470-4212-b462-7e26eb6b8d53)


```
		"@tsconfig/node16": "^16.1.1",
		"@tsconfig/strictest": "^2.0.2",
		"typescript": "~5.2.2",
```
```json
{
	"extends": ["@tsconfig/node16/tsconfig.json", "@tsconfig/strictest/tsconfig.json"],
	"compilerOptions": {
		"outDir": "dist",
		"declaration": true,
		"sourceMap": true
	},
	"include": ["srv/**/*.ts"],
	"exclude": ["node_modules", "dist"]
}
```