### PR TITLE
docs: update import method in cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install axios-retry
 
 ```js
 // CommonJS
-// const axiosRetry = require('axios-retry');
+// const axiosRetry = require('axios-retry').default;
 
 // ES6
 import axiosRetry from 'axios-retry';


### PR DESCRIPTION
This ought to fix https://github.com/softonic/axios-retry/issues/257.

With the migration to TypeScript, `.default` is now required in cjs. I have changed my README to accommodate that change.

I don't think this change in the README is destructive, because even before v4.0.0 it was exported as `module.exports.default = axiosRetry;`.
https://github.com/softonic/axios-retry/blob/v3.9.1/index.js#L4

