### PR TITLE
feat: abortable retry delay

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,5 @@
   "printWidth": 100,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "none",
-  "endOfLine": "auto"
+  "trailingComma": "none"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "printWidth": 100,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
### Context
If a web application implements `axios-retry` and also a network change detection system, he may want to re-call the API requests even if in the middle of the retries.

### Problem
Currently, there is no way to clear the `setTimeout` and reject the `Promise` that handles the retries' attempts.

### Solution
Implement the possibility to pass an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)'s [signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), so that a developer is able to stop pending retries.