### PR TITLE
Support retry on 200 response

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ client
 | retryDelay | `Function` | `function noDelay() { return 0; }` | A callback to further control the delay in milliseconds between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
 | onRetry | `Function` | `function onRetry(retryCount, error, requestConfig) { return; }` | A callback to notify when a retry is about to occur. Useful for tracing and you can any async process for example refresh a token on 401. By default nothing will occur. The function is passed `retryCount`, `error`, and `requestConfig`. |
 | onMaxRetryTimesExceeded | `Function` | `function onMaxRetryTimesExceeded(error, retryCount) { return; }` | After all the retries are failed, this callback will be called with the last error before throwing the error. |
+| validateResponse | `Function | null` | `null` | A callback to define whether a response should be resolved or rejected. If null is passed, it will fallback to the axios default (only 2xx status codes are resolved). |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ client
 | retryDelay | `Function` | `function noDelay() { return 0; }` | A callback to further control the delay in milliseconds between retried requests. By default there is no delay between retries. Another option is exponentialDelay ([Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff)). The function is passed `retryCount` and `error`. |
 | onRetry | `Function` | `function onRetry(retryCount, error, requestConfig) { return; }` | A callback to notify when a retry is about to occur. Useful for tracing and you can any async process for example refresh a token on 401. By default nothing will occur. The function is passed `retryCount`, `error`, and `requestConfig`. |
 | onMaxRetryTimesExceeded | `Function` | `function onMaxRetryTimesExceeded(error, retryCount) { return; }` | After all the retries are failed, this callback will be called with the last error before throwing the error. |
-| validateResponse | `Function | null` | `null` | A callback to define whether a response should be resolved or rejected. If null is passed, it will fallback to the axios default (only 2xx status codes are resolved). |
+| validateResponse | `Function \| null` | `null` | A callback to define whether a response should be resolved or rejected. If null is passed, it will fallback to the axios default (only 2xx status codes are resolved). |
 
 ## Testing
 

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1,6 +1,6 @@
 import http from 'http';
 import nock from 'nock';
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosError, isAxiosError } from 'axios';
 import axiosRetry, {
   isNetworkError,
   isSafeRequestError,
@@ -391,6 +391,115 @@ describe('axiosRetry(axios, { retries, retryCondition })', () => {
         expect(result.status).toBe(200);
         done();
       }, done.fail);
+  });
+});
+
+describe('axiosRetry(axios, { validateResponse })', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('when validateResponse is supplied as default option', () => {
+    it('should be able to produce an AxiosError with status code of 200', (done) => {
+      const client = axios.create();
+      setupResponses(client, [
+        () => nock('http://example.com').get('/test').reply(200, 'should retry!')
+      ]);
+      axiosRetry(client, {
+        retries: 0,
+        validateResponse: (response) => response.status !== 200
+      });
+      client.get('http://example.com/test').catch((err) => {
+        expect(isAxiosError(err)).toBeTrue();
+        expect(err.response.status).toBe(200);
+        done();
+      });
+    });
+
+    it('should retry based on supplied logic', (done) => {
+      const client = axios.create();
+      setupResponses(client, [
+        () => nock('http://example.com').get('/test').reply(200, 'should retry!'),
+        () => nock('http://example.com').get('/test').replyWithError(NETWORK_ERROR),
+        () => nock('http://example.com').get('/test').reply(200, 'should retry!'),
+        () => nock('http://example.com').get('/test').reply(200, 'ok!')
+      ]);
+      let retryCount = 0;
+      axiosRetry(client, {
+        retries: 4,
+        retryCondition: () => true,
+        retryDelay: () => {
+          retryCount += 1;
+          return 0;
+        },
+        validateResponse: (response) => {
+          if (response.status < 200 || response.status >= 300) return false;
+          return response.data === 'ok!';
+        }
+      });
+      client.get('http://example.com/test').then((result) => {
+        expect(retryCount).toBe(3);
+        expect(result.status).toBe(200);
+        expect(result.data).toBe('ok!');
+        done();
+      }, done.fail);
+    });
+  });
+
+  describe('when validateResponse is supplied as request-specific configuration', () => {
+    it('should use request-specific configuration instead', (done) => {
+      const client = axios.create();
+      setupResponses(client, [
+        () => nock('http://example.com').get('/test').reply(200, 'should retry!'),
+        () => nock('http://example.com').get('/test').replyWithError(NETWORK_ERROR),
+        () => nock('http://example.com').get('/test').reply(200, 'ok!')
+      ]);
+      axiosRetry(client, {
+        validateResponse: (response) => response.status >= 200 && response.status < 300
+      });
+      client
+        .get('http://example.com/test', {
+          'axios-retry': {
+            retryCondition: () => true,
+            validateResponse: (response) => {
+              if (response.status < 200 || response.status >= 300) return false;
+              return response.data === 'ok!';
+            }
+          }
+        })
+        .then((result) => {
+          expect(result.status).toBe(200);
+          expect(result.data).toBe('ok!');
+          done();
+        }, done.fail);
+    });
+
+    it('should be able to disable default validateResponse passed', (done) => {
+      const client = axios.create();
+      setupResponses(client, [
+        () => nock('http://example.com').get('/test').reply(200, 'should not retry!'),
+        () => nock('http://example.com').get('/test').replyWithError(NETWORK_ERROR),
+        () => nock('http://example.com').get('/test').reply(200, 'ok!')
+      ]);
+      axiosRetry(client, {
+        validateResponse: (response) => {
+          if (response.status < 200 || response.status >= 300) return false;
+          return response.data === 'ok!';
+        }
+      });
+      client
+        .get('http://example.com/test', {
+          'axios-retry': {
+            retryCondition: () => true,
+            validateResponse: null
+          }
+        })
+        .then((result) => {
+          expect(result.status).toBe(200);
+          expect(result.data).toBe('should not retry!');
+          done();
+        }, done.fail);
+    });
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ export interface IAxiosRetryConfig {
    */
   onMaxRetryTimesExceeded?: (error: AxiosError, retryCount: number) => Promise<void> | void;
   /**
-   * Defines whether a response should be resolved or rejected
+   * A callback to define whether a response should be resolved or rejected. If null is passed, it will fallback to
+   * the axios default (only 2xx status codes are resolved).
    */
   validateResponse?: ((response: AxiosResponse) => boolean) | null;
 }


### PR DESCRIPTION
This solves #267  

Before we couldn't retry on any 200 response. This will add functionality that supports retrying for any logic defined by the user.