### PR TITLE
Tighten range of test retry times

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,7 +25,6 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1080,7 +1080,7 @@ describe('exponentialDelay', () => {
   it('should return exponential retry delay', () => {
     function assertTime(retryCount) {
       const min = Math.pow(2, retryCount) * 100;
-      const max = Math.pow(2, retryCount * 100) * 0.2;
+      const max = min * 1.2;
       const time = exponentialDelay(retryCount);
 
       expect(time >= min && time <= max).toBe(true);
@@ -1092,7 +1092,7 @@ describe('exponentialDelay', () => {
   it('should change delay time when specifying delay factor', () => {
     function assertTime(retryCount) {
       const min = Math.pow(2, retryCount) * 1000;
-      const max = Math.pow(2, retryCount * 1000) * 0.2;
+      const max = min * 1.2;
       const time = exponentialDelay(retryCount, undefined, 1000);
 
       expect(time >= min && time <= max).toBe(true);


### PR DESCRIPTION
As pointed out by @mathieusaade in #302, it probably makes a bit more sense to check the ranges for exponential within a tighter boundary so if we do ever modify the formula, we still keep human time frames.